### PR TITLE
[#108] : 찜한 모임 해제 시 오류 해결 및 모임 생성 실시간 등록

### DIFF
--- a/src/components/common/FavoriteButton.tsx
+++ b/src/components/common/FavoriteButton.tsx
@@ -33,15 +33,16 @@ const FavoriteButton = ({ moimId }: FavoriteButtonProps) => {
       return;
     }
 
-    setIsFavorite((prev: boolean) => {
-      const next = !prev;
+    const next = !isFavorite;
+    setIsFavorite(next);
+    // 렌더링 중 다른 컴포넌트 업데이트 방지
+    setTimeout(() => {
       if (next) {
         addFavoriteMoim(moimId, userId);
       } else {
         removeFavoriteMoim(moimId, userId);
       }
-      return next;
-    });
+    }, 0);
   };
   return (
     <>

--- a/src/hooks/useMoimFindQuery.ts
+++ b/src/hooks/useMoimFindQuery.ts
@@ -82,7 +82,10 @@ export const useCreateMoimMutation = (teamName: string = TEAM_NAME) => {
   return useMutation({
     mutationFn: (payload: CreateMoimRequest) => postMoim(payload, teamName),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["moims", teamName] });
+      // "moims"로 시작하는 모든 쿼리 무효화 (infinite 쿼리 포함)
+      void queryClient.invalidateQueries({ queryKey: ["moims"] });
+      // 마이페이지의 생성한 모임 목록도 무효화
+      void queryClient.invalidateQueries({ queryKey: ["mypage", "createdMoims"] });
     },
   });
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #108 

## 📝작업 내용

> 🚨트러블슈팅: 찜한 모임 해제 시, 오류

> 모임 생성 시, 실시간 목록 조회

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
